### PR TITLE
chore(ci): disable selected workflows and normalize YAML formatting

### DIFF
--- a/.github/workflows/on-demand-description.yml
+++ b/.github/workflows/on-demand-description.yml
@@ -2,48 +2,48 @@
 # Generates descriptions when the "augment_describe" label is added to a PR
 
 name: On-Demand PR Description
-on:
-  pull_request:
-    types: [labeled]
+#on:
+#  pull_request:
+#    types: [labeled]
 
 jobs:
   describe:
     # Only run when the specific label is added
-    if: github.event.label.name == 'augment_describe'
+    if:      github.event.label.name == 'augment_describe'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents:      read
       pull-requests: write
     steps:
       - name: Generate PR Description
         uses: augmentcode/describe-pr@v0
         with:
           augment_session_auth: ${{ secrets.AUGMENT_SESSION_AUTH }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_number: ${{ github.event.pull_request.number }}
-          repo_name: ${{ github.repository }}
+          github_token:         ${{ secrets.GITHUB_TOKEN }}
+          pull_number:          ${{ github.event.pull_request.number }}
+          repo_name:            ${{ github.repository }}
 
       - name: Remove trigger label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
-            // Remove the trigger label after processing
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'augment_describe'
-            });
+                  // Remove the trigger label after processing
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: 'augment_describe'
+                  });
 
       - name: Add completion label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
-            // Add a label to indicate the description was generated
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['auto-described']
-            });
+                  // Add a label to indicate the description was generated
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    labels: ['auto-described']
+                  });
 

--- a/.github/workflows/on-demand-review.yml
+++ b/.github/workflows/on-demand-review.yml
@@ -2,48 +2,48 @@
 # Generates reviews when the "augment_review" label is added to a PR
 
 name: On-Demand PR Review
-on:
-  pull_request:
-    types: [labeled]
+#on:
+#  pull_request:
+#    types: [labeled]
 
 jobs:
   review:
     # Only run when the specific label is added
-    if: github.event.label.name == 'augment_review'
+    if:      github.event.label.name == 'augment_review'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents:      read
       pull-requests: write
     steps:
       - name: Generate PR Review
         uses: augmentcode/review-pr@v0
         with:
           augment_session_auth: ${{ secrets.AUGMENT_SESSION_AUTH }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_number: ${{ github.event.pull_request.number }}
-          repo_name: ${{ github.repository }}
+          github_token:         ${{ secrets.GITHUB_TOKEN }}
+          pull_number:          ${{ github.event.pull_request.number }}
+          repo_name:            ${{ github.repository }}
 
       - name: Remove trigger label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
-            // Remove the trigger label after processing
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'augment_review'
-            });
+                  // Remove the trigger label after processing
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: 'augment_review'
+                  });
 
       - name: Add completion label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
-            // Add a label to indicate the review was generated
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['auto-reviewed']
-            });
+                  // Add a label to indicate the review was generated
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    labels: ['auto-reviewed']
+                  });
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
-on:
-  push:
-    tags:
-      - "v*.*.*"
+#on:
+#  push:
+#    tags:
+#      - "v*.*.*"
 
 permissions:
   contents: write
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token:       ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
@@ -26,106 +26,106 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run:  bun install
 
       - name: Type check
-        run: bun run typecheck
+        run:  bun run typecheck
 
       - name: Extract version from tag
-        id: version
-        run: |
-          TAG_NAME=${GITHUB_REF#refs/tags/}
-          VERSION=${TAG_NAME#v}
-          MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
-          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "major_version=v$MAJOR_VERSION" >> $GITHUB_OUTPUT
+        id:   version
+        run:  |
+              TAG_NAME=${GITHUB_REF#refs/tags/}
+              VERSION=${TAG_NAME#v}
+              MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
+              echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+              echo "version=$VERSION" >> $GITHUB_OUTPUT
+              echo "major_version=v$MAJOR_VERSION" >> $GITHUB_OUTPUT
 
       - name: Verify package.json version matches tag
-        run: |
-          PACKAGE_VERSION=$(jq -r '.version' package.json)
-          if [ "$PACKAGE_VERSION" != "${{ steps.version.outputs.version }}" ]; then
-            echo "❌ Version mismatch: package.json has $PACKAGE_VERSION but tag is ${{ steps.version.outputs.version }}"
-            exit 1
-          fi
-          echo "✅ Version verified: $PACKAGE_VERSION"
+        run:  |
+              PACKAGE_VERSION=$(jq -r '.version' package.json)
+              if [ "$PACKAGE_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+                echo "❌ Version mismatch: package.json has $PACKAGE_VERSION but tag is ${{ steps.version.outputs.version }}"
+                exit 1
+              fi
+              echo "✅ Version verified: $PACKAGE_VERSION"
 
       - name: Update major version tag
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -f "${{ steps.version.outputs.major_version }}" -m "Release ${{ steps.version.outputs.major_version }} (latest)"
-          git push origin "${{ steps.version.outputs.major_version }}" --force
+        run:  |
+              git config --global user.name "github-actions[bot]"
+              git config --global user.email "github-actions[bot]@users.noreply.github.com"
+              git tag -f "${{ steps.version.outputs.major_version }}" -m "Release ${{ steps.version.outputs.major_version }} (latest)"
+              git push origin "${{ steps.version.outputs.major_version }}" --force
 
       - name: Create GitHub Release
-        run: |
-          # Create release body content
-          RELEASE_BODY=$(cat << 'EOF'
-          ## Release ${{ steps.version.outputs.tag_name }}
-
-          ### Quick Usage
-          ```yaml
-          - uses: augmentcode/augment-agent@${{ steps.version.outputs.tag_name }}
-            with:
-              augment_api_token: ${{ secrets.AUGMENT_API_TOKEN }}
-              augment_api_url: ${{ vars.AUGMENT_API_URL }}
-              github_token: ${{ secrets.GITHUB_TOKEN }}
-              instruction_file: /tmp/instruction.txt
-          ```
-
-          ### Major Version Tag
-          You can also use the major version tag for automatic updates:
-          ```yaml
-          - uses: augmentcode/augment-agent@${{ steps.version.outputs.major_version }}
-          ```
-
-          ### Documentation
-          - 📖 [Full Documentation](https://github.com/augmentcode/augment-agent#readme)
-          - 🚀 [Quick Start Guide](https://github.com/augmentcode/augment-agent#quick-start)
-          - ⚙️ [Configuration Options](https://github.com/augmentcode/augment-agent#inputs)
-          - 💡 [Example Workflows](https://github.com/augmentcode/augment-agent#example-workflows)
-          EOF
-          )
-
-          # Create the release using GitHub REST API
-          echo "📡 Creating GitHub release..."
-          RESPONSE=$(curl -s -w "%{http_code}" -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/releases \
-            -d "$(jq -n \
-              --arg tag_name "${{ steps.version.outputs.tag_name }}" \
-              --arg name "Release ${{ steps.version.outputs.tag_name }}" \
-              --arg body "${RELEASE_BODY}" \
-              '{
-                "tag_name": $tag_name,
-                "target_commitish": "main",
-                "name": $name,
-                "body": $body,
-                "draft": false,
-                "prerelease": false
-              }')")
-
-          # Extract HTTP status code (last 3 characters)
-          HTTP_CODE="${RESPONSE: -3}"
-          RESPONSE_BODY="${RESPONSE%???}"
-
-          # Check if the request was successful
-          if [ "$HTTP_CODE" -eq 201 ]; then
-            echo "✅ Successfully created release ${{ steps.version.outputs.tag_name }}"
-
-            # Extract and display the release URL if available
-            RELEASE_URL=$(echo "$RESPONSE_BODY" | jq -r '.html_url // empty')
-            if [ -n "$RELEASE_URL" ]; then
-              echo "🔗 Release URL: $RELEASE_URL"
-            fi
-
-            echo "🎉 Release process completed successfully!"
-          else
-            echo "❌ Failed to create release. HTTP status: $HTTP_CODE"
-            echo "Response: $RESPONSE_BODY"
-            exit 1
-          fi
+        run:  |
+              # Create release body content
+              RELEASE_BODY=$(cat << 'EOF'
+              ## Release ${{ steps.version.outputs.tag_name }}
+              
+              ### Quick Usage
+              ```yaml
+              - uses: augmentcode/augment-agent@${{ steps.version.outputs.tag_name }}
+                with:
+                  augment_api_token: ${{ secrets.AUGMENT_API_TOKEN }}
+                  augment_api_url: ${{ vars.AUGMENT_API_URL }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  instruction_file: /tmp/instruction.txt
+              ```
+              
+              ### Major Version Tag
+              You can also use the major version tag for automatic updates:
+              ```yaml
+              - uses: augmentcode/augment-agent@${{ steps.version.outputs.major_version }}
+              ```
+              
+              ### Documentation
+              - 📖 [Full Documentation](https://github.com/augmentcode/augment-agent#readme)
+              - 🚀 [Quick Start Guide](https://github.com/augmentcode/augment-agent#quick-start)
+              - ⚙️ [Configuration Options](https://github.com/augmentcode/augment-agent#inputs)
+              - 💡 [Example Workflows](https://github.com/augmentcode/augment-agent#example-workflows)
+              EOF
+              )
+              
+              # Create the release using GitHub REST API
+              echo "📡 Creating GitHub release..."
+              RESPONSE=$(curl -s -w "%{http_code}" -L \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/${{ github.repository }}/releases \
+                -d "$(jq -n \
+                  --arg tag_name "${{ steps.version.outputs.tag_name }}" \
+                  --arg name "Release ${{ steps.version.outputs.tag_name }}" \
+                  --arg body "${RELEASE_BODY}" \
+                  '{
+                    "tag_name": $tag_name,
+                    "target_commitish": "main",
+                    "name": $name,
+                    "body": $body,
+                    "draft": false,
+                    "prerelease": false
+                  }')")
+              
+              # Extract HTTP status code (last 3 characters)
+              HTTP_CODE="${RESPONSE: -3}"
+              RESPONSE_BODY="${RESPONSE%???}"
+              
+              # Check if the request was successful
+              if [ "$HTTP_CODE" -eq 201 ]; then
+                echo "✅ Successfully created release ${{ steps.version.outputs.tag_name }}"
+              
+                # Extract and display the release URL if available
+                RELEASE_URL=$(echo "$RESPONSE_BODY" | jq -r '.html_url // empty')
+                if [ -n "$RELEASE_URL" ]; then
+                  echo "🔗 Release URL: $RELEASE_URL"
+                fi
+              
+                echo "🎉 Release process completed successfully!"
+              else
+                echo "❌ Failed to create release. HTTP status: $HTTP_CODE"
+                echo "Response: $RESPONSE_BODY"
+                exit 1
+              fi
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -11,12 +11,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Skip if secret not set
-        if: ${{ !secrets.AUGMENT_SESSION_AUTH }}
-        run: echo "Skipping: AUGMENT_SESSION_AUTH is not configured in repo secrets."
+        if:   ${{ !secrets.AUGMENT_SESSION_AUTH }}
+        run:
+          echo "Skipping: AUGMENT_SESSION_AUTH is not configured in repo secrets."
 
       - name: Test Augment Agent (public action)
-        if: ${{ secrets.AUGMENT_SESSION_AUTH }}
+        if:   ${{ secrets.AUGMENT_SESSION_AUTH }}
         uses: augmentcode/augment-agent@v1
         with:
           augment_session_auth: ${{ secrets.AUGMENT_SESSION_AUTH }}
-          instruction: "Say hello"
+          instruction:          "Say hello"

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,8 +12,8 @@ jobs:
 
       - name: Skip if secret not set
         if:   ${{ !secrets.AUGMENT_SESSION_AUTH }}
-        run:
-          echo "Skipping: AUGMENT_SESSION_AUTH is not configured in repo secrets."
+        run:  |
+              echo "Skipping: AUGMENT_SESSION_AUTH is not configured in repo secrets."
 
       - name: Test Augment Agent (public action)
         if:   ${{ secrets.AUGMENT_SESSION_AUTH }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,10 +1,10 @@
 name: TimeLocker Test Suite
 
-on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+#on:
+#  push:
+#    branches: [main, develop]
+#  pull_request:
+#    branches: [main, develop]
 
 jobs:
   test:


### PR DESCRIPTION
Disable CI workflow triggers and normalize YAML formatting

This PR temporarily disables selected GitHub Actions workflows to prevent unintended runs during CI infrastructure work, while standardizing the YAML formatting across all workflow files.

**Changes:**
- Comment out workflow triggers (`on:` sections) in on-demand description/review, release, and test-suite workflows
- Normalize indentation and spacing throughout all workflow YAML files  
- Improve formatting consistency in inline script blocks
- Structure the test-action workflow with better organized skip step

**Impact:**
- Workflows remain defined but won't trigger automatically
- Cleaner, more maintainable workflow files with consistent formatting
- Safe to merge - only affects when workflows execute, not their functionality

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*