### PR TITLE
chore(workflows): clarify triage prompt responsibilities and Issue Type handling

### DIFF
--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -4,8 +4,8 @@ on:
     types: [opened]
 
 permissions:
-  contents: read
-  issues: write
+  contents:      read
+  issues:        write
   pull-requests: write
 
 jobs:
@@ -22,41 +22,43 @@ jobs:
           ISSUE_TITLE:    ${{ github.event.issue.title }}
           ISSUE_AUTHOR:   ${{ github.event.issue.user.login }}
           CURRENT_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
-        run: |
-          cat > /tmp/triage-instruction.txt << 'EOF'
-          Analyze the following GitHub issue and provide comprehensive triage recommendations:
+        run:  |
+              cat > /tmp/triage-instruction.txt << 'EOF'
+              Analyze the following GitHub issue and provide comprehensive triage recommendations:
+              
+              **Issue Information:**
+              - Issue Number: ${ISSUE_NUMBER}
+              - Repository: ${REPOSITORY}
+              - Title: ${ISSUE_TITLE}
+              - Author: ${ISSUE_AUTHOR}
+              - Current Labels: ${CURRENT_LABELS}
+              
+              **Triage Analysis:**
+              Please analyze this issue and provide detailed triage recommendations including:
+              - **Priority Level**: Assess urgency and impact (Critical/High/Medium/Low)
+              - **Issue Type**: Categorize the issue (bug, feature request, enhancement, documentation, question, etc.)
+              - **Complexity Estimate**: Evaluate implementation complexity (Simple/Medium/Complex)
+              - **Suggested Labels**: Recommend appropriate labels for categorization
+              - **Team/Component**: Identify which team or component this issue relates to
+              - **Dependencies**: Note any dependencies or blockers mentioned
+              - **Reproducibility**: For bugs, assess if reproduction steps are clear
+              - **Acceptance Criteria**: Identify if requirements are well-defined
+              - **Similar Issues**: Note if this appears related to existing issues
+              
+              **Recommendations:**
+              - Suggest next steps for handling this issue
+              - Recommend if additional information is needed from the reporter
+              - Identify potential assignees or teams based on the issue content
+              - Note any immediate actions that should be taken
+              
+              Focus on providing actionable insights that will help maintainers efficiently process and prioritize this issue.
+              
+              Update the Issue labels based on the analysis. If a recommended label does not exist, create it first; then add it to the issue. Do not remove existing labels. Set exactly one priority:* label.
 
-          **Issue Information:**
-          - Issue Number: ${ISSUE_NUMBER}
-          - Repository: ${REPOSITORY}
-          - Title: ${ISSUE_TITLE}
-          - Author: ${ISSUE_AUTHOR}
-          - Current Labels: ${CURRENT_LABELS}
+              Recommend the Issue Type (Bug, Feature, or Task) based on the analysis.
 
-          **Triage Analysis:**
-          Please analyze this issue and provide detailed triage recommendations including:
-          - **Priority Level**: Assess urgency and impact (Critical/High/Medium/Low)
-          - **Issue Type**: Categorize the issue (bug, feature request, enhancement, documentation, question, etc.)
-          - **Complexity Estimate**: Evaluate implementation complexity (Simple/Medium/Complex)
-          - **Suggested Labels**: Recommend appropriate labels for categorization
-          - **Team/Component**: Identify which team or component this issue relates to
-          - **Dependencies**: Note any dependencies or blockers mentioned
-          - **Reproducibility**: For bugs, assess if reproduction steps are clear
-          - **Acceptance Criteria**: Identify if requirements are well-defined
-          - **Similar Issues**: Note if this appears related to existing issues
-
-          **Recommendations:**
-          - Suggest next steps for handling this issue
-          - Recommend if additional information is needed from the reporter
-          - Identify potential assignees or teams based on the issue content
-          - Note any immediate actions that should be taken
-
-          Focus on providing actionable insights that will help maintainers efficiently process and prioritize this issue.
-
-          Update the Issue labels based on the analysis.
-
-          Please post your triage analysis as a comment on the issue.
-          EOF
+              Please post your triage analysis as a comment on the issue.
+              EOF
       - name: Triage Issue
         uses: augmentcode/augment-agent@v0
         with:


### PR DESCRIPTION
Improve GitHub issue triage workflow with clearer responsibilities and label handling

This PR enhances the automated issue triage workflow to prevent label conflicts and clarify the division of responsibilities between the Augment Agent and the workflow system.

**Key improvements:**
- **Label management**: Instructs the agent to create missing labels before applying them and preserve existing labels to prevent label churn
- **Priority enforcement**: Requires exactly one `priority:*` label to be set, eliminating priority ambiguity  
- **Issue Type clarification**: Agent now recommends Issue Type (Bug/Feature/Task) in triage comments while the workflow handles setting the official Issue Type field
- **Enhanced formatting**: Improved indentation and structure for better readability and maintainability

These changes align the triage process with repository policy that treats Issue Type as a first-class field rather than a label, while establishing clear boundaries between automated analysis and workflow actions.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*