### PR TITLE
docs: update installation instructions to pyproject and fix repo links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ By participating in this project, you agree to abide by the [Code of Conduct](CO
 ### Reporting Bugs
 
 Before submitting a bug report:
-- Check the [issue tracker](https://github.com/yourusername/TimeLocker/issues) to see if the issue has already been reported.
-- If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/yourusername/TimeLocker/issues/new).
+- Check the [issue tracker](https://github.com/Auriora/TimeLocker/issues) to see if the issue has already been reported.
+- If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/Auriora/TimeLocker/issues/new).
 
 When reporting bugs, please include:
 - A clear and descriptive title
@@ -24,7 +24,7 @@ When reporting bugs, please include:
 
 ### Suggesting Enhancements
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/yourusername/TimeLocker/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/Auriora/TimeLocker/issues).
 - Use a clear and descriptive title
 - Provide a detailed description of the suggested enhancement
 - Explain why this enhancement would be useful
@@ -44,13 +44,13 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/yourus
 
 1. Clone the repository
    ```bash
-   git clone https://github.com/yourusername/TimeLocker.git
+   git clone https://github.com/Auriora/TimeLocker.git
    cd TimeLocker
    ```
 
 2. Install dependencies
    ```bash
-   pip install -r requirements.txt
+   pip install -e ".[dev]"
    ```
 
 3. Run tests
@@ -78,6 +78,6 @@ By contributing to TimeLocker, you agree that your contributions will be license
 
 ## Questions?
 
-If you have any questions, please feel free to [open an issue](https://github.com/yourusername/TimeLocker/issues/new) or contact the maintainers directly.
+If you have any questions, please feel free to [open an issue](https://github.com/Auriora/TimeLocker/issues/new) or contact the maintainers directly.
 
 Thank you for contributing to TimeLocker!

--- a/docs/3-implementation/README.md
+++ b/docs/3-implementation/README.md
@@ -78,8 +78,8 @@ cd TimeLocker
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
-# Install dependencies
-pip install -r requirements.txt
+# Install in editable mode with dev dependencies (PEP 660)
+pip install -e ".[dev]"
 
 # Run tests
 pytest


### PR DESCRIPTION
This PR updates documentation to remove remaining references to deprecated installation methods and fixes placeholder repository links.

What changed
- Replace requirements.txt installation steps with modern editable install (PEP 660) using pyproject.toml
- Update GitHub links from placeholder `yourusername` to `Auriora`
- Correct clone URLs and issue tracker links

Why
- Align docs with modern Python packaging and current repository structure
- Prevent confusion and ensure link checkers pass

Files updated
- docs/3-implementation/README.md: use `pip install -e ".[dev]"`
- CONTRIBUTING.md: fix issue tracker/new issue links, clone URL, and dev install instructions

Testing/Verification
- CLI help runs: `python3 -m TimeLocker.cli --help` (exit code 0)
- Targeted tests: `pytest -q tests/test_version_management.py` -> 10 passed

References
- Closes #27

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author