### PR TITLE
docs(cli-docs): update docs to new CLI hierarchy and file:// requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,18 @@ our [Installation Guide](docs/INSTALLATION.md).
 #### Command Line Interface
 
 ```bash
-# Initialize a new repository
-timelocker init --repository /path/to/repo
+# Add and initialize a local repository (file:// is required for local paths)
+tl repos add myrepo file:///path/to/repo --default
+tl repos init myrepo
 
-# Create a backup
-timelocker backup --repository /path/to/repo /home/user/documents
+# Create a backup (sources can be specified directly or via a target)
+tl backup create --repository myrepo /home/user/documents
 
-# List snapshots
-timelocker list --repository /path/to/repo
+# List snapshots (for a specific repo; omit --repository to use default behavior if applicable)
+tl snapshots list --repository myrepo
 
-# Restore from backup
-timelocker restore --repository /path/to/repo --snapshot abc123 /restore/path
+# Restore from a snapshot
+tl snapshots restore abc123 /restore/path --repository myrepo
 ```
 
 Note: Credentials are resolved via the Credential Manager (preferred), then the TIMELOCKER_PASSWORD environment variable, then RESTIC_PASSWORD. The --password flag has been removed from CLI commands.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ our [Installation Guide](docs/INSTALLATION.md).
 
 ```bash
 # Add and initialize a local repository (file:// is required for local paths)
-tl repos add myrepo file:///path/to/repo --default
+tl repos add myrepo file:///path/to/repo --set-default
 tl repos init myrepo
 
 # Create a backup (sources can be specified directly or via a target)

--- a/docs/repository_management_guide.md
+++ b/docs/repository_management_guide.md
@@ -148,6 +148,8 @@ export RESTIC_REPOSITORY="s3:s3.region.amazonaws.com/bucket"
 export RESTIC_PASSWORD="your-password"
 tl config import restic
 ```
+> Note: `tl config import restic` is not yet implemented in the current CLI. Please configure repositories manually using `tl repos add` and set the default with `tl repos default`.
+
 
 ### Manual Migration
 

--- a/docs/repository_uri_guide.md
+++ b/docs/repository_uri_guide.md
@@ -286,6 +286,8 @@ export RESTIC_PASSWORD="your-password"
 # Then import
 tl config import restic
 ```
+> Note: `tl config import restic` is not yet implemented in the current CLI. Please add repositories manually with `tl repos add` and set a default with `tl repos default`.
+
 
 ## 🔐 **Security Notes**
 

--- a/docs/repository_uri_guide.md
+++ b/docs/repository_uri_guide.md
@@ -11,7 +11,6 @@ Store backups on local disk or mounted drives.
 **Format:**
 
 ```
-/path/to/repository
 file:///path/to/repository
 ```
 
@@ -19,16 +18,13 @@ file:///path/to/repository
 
 ```bash
 # Local directory
-/home/user/backups/restic-repo
+file:///home/user/backups/restic-repo
 
 # External drive
-/mnt/backup-drive/restic-repo
+file:///mnt/backup-drive/restic-repo
 
 # Network mounted drive
-/mnt/nas/backups/restic-repo
-
-# Explicit file protocol
-file:///home/user/backups/restic-repo
+file:///mnt/nas/backups/restic-repo
 ```
 
 ### 2. **AWS S3**
@@ -233,7 +229,7 @@ echo $RESTIC_REPOSITORY
 ### Method 2: Check TimeLocker Configuration
 
 ```bash
-cd src && python3 -m TimeLocker.cli config list-repos
+tl repos list
 ```
 
 ### Method 3: Check Original Configuration Files
@@ -258,7 +254,7 @@ sudo cat /var/restic/.resticrc | grep RESTIC_REPOSITORY
 
 1. **Create directory:** `mkdir -p /path/to/backup/repo`
 2. **Set permissions:** `chmod 700 /path/to/backup/repo`
-3. **Use path as URI:** `/path/to/backup/repo`
+3. **Use URI:** `file:///path/to/backup/repo`
 
 ### For SFTP:
 
@@ -271,13 +267,13 @@ sudo cat /var/restic/.resticrc | grep RESTIC_REPOSITORY
 ### List Snapshots:
 
 ```bash
-cd src && python3 -m TimeLocker.cli list -r "s3:s3.af-south-1.amazonaws.com/5560-restic"
+tl snapshots list --repository "s3:s3.af-south-1.amazonaws.com/5560-restic"
 ```
 
 ### Create Backup:
 
 ```bash
-cd src && python3 -m TimeLocker.cli backup -r "s3:s3.af-south-1.amazonaws.com/5560-restic" /path/to/backup
+tl backup create --repository "s3:s3.af-south-1.amazonaws.com/5560-restic" /path/to/backup
 ```
 
 ### Import from Environment:
@@ -288,7 +284,7 @@ export RESTIC_REPOSITORY="s3:s3.region.amazonaws.com/bucket"
 export RESTIC_PASSWORD="your-password"
 
 # Then import
-cd src && python3 -m TimeLocker.cli config import-restic
+tl config import restic
 ```
 
 ## 🔐 **Security Notes**


### PR DESCRIPTION
Update documentation to reflect current CLI command hierarchy and enforce `file://` URI requirements

This PR aligns documentation with the implemented CLI structure and URI validation rules to ensure users have accurate guidance.

**Key Changes:**
- **CLI Command Updates**: Replace legacy `tl config add-repo/list-repos/set-default-repo/remove-repo` commands with new `tl repos add/list/default/remove` hierarchy
- **URI Format Enforcement**: Require `file://` prefix for all local filesystem paths (e.g., `file:///path/to/repo` instead of `/path/to/repo`)
- **Command Examples**: Update all documentation examples to use current command structure (`tl snapshots list`, `tl backup create`, `tl backup verify`)
- **Import Command**: Update restic import syntax from `tl config import-restic` to `tl config import restic`

**Files Updated:**
- README.md: Quick start examples and command reference
- docs/repository_management_guide.md: Repository management workflows and examples  
- docs/repository_uri_guide.md: URI format specifications and usage examples

This ensures users following the documentation will use the correct commands and URI formats that match the current implementation.

Refs #12

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*