### PR TITLE
feat(cli): validate snapshot IDs and repository names

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -3,9 +3,9 @@ name: TimeLocker Test Suite
 on:
   workflow_dispatch:
 #  push:
-#    branches: [main, develop]
+#    branches: [main, staging]
 #  pull_request:
-#    branches: [main, develop]
+#    branches: [main, staging]
 
 jobs:
   test:
@@ -83,13 +83,13 @@ jobs:
         env:
           PYTHONPATH: src
         run:  |
-              pytest tests/TimeLocker/ -v --tb=short --maxfail=10
+              pytest tests/TimeLocker/ -v --tb=short --maxfail=10 -m "not performance"
 
       - name: Run unit tests with coverage
         env:
           PYTHONPATH: src
         run:  |
-              pytest tests/TimeLocker/ --cov=src --cov-report=xml --cov-report=html --cov-report=term-missing --cov-fail-under=70
+              pytest tests/TimeLocker/ --cov=src --cov-report=xml --cov-report=html --cov-report=term-missing --cov-fail-under=70 -m "not performance"
 
       - name: Run integration tests
         env:
@@ -108,6 +108,13 @@ jobs:
           PYTHONPATH: src
         run:  |
               pytest tests/TimeLocker/backup/test_critical_backup_paths.py -v --tb=short
+
+      - name: Run performance tests (serial)
+        env:
+          PYTHONPATH: src
+        run:  |
+              pytest -n 0 -vv -s -m "performance"
+
 
       - name: Upload coverage reports to Codecov
         if:   matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
@@ -283,22 +290,22 @@ jobs:
         with:
           script: |
                   const fs = require('fs');
-                  
+
                   try {
                     const qualityReport = JSON.parse(fs.readFileSync('quality-report.json', 'utf8'));
-                  
+
                     const comment = `## 🧪 Test Results
-                  
+
                     | Metric | Value | Status |
                     |--------|-------|--------|
                     | Coverage | ${qualityReport.coverage_percentage.toFixed(1)}% | ${qualityReport.coverage_passed ? '✅' : '❌'} |
                     | Threshold | ${qualityReport.coverage_threshold}% | - |
-                  
+
                     ${qualityReport.coverage_passed ?
                       '✅ All quality gates passed!' :
                       '❌ Quality gates failed. Please improve test coverage to meet the threshold.'}
                     `;
-                  
+
                     github.rest.issues.createComment({
                       issue_number: context.issue.number,
                       owner: context.repo.owner,

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -83,31 +83,31 @@ jobs:
         env:
           PYTHONPATH: src
         run:  |
-              pytest tests/TimeLocker/ -v --tb=short --maxfail=10 -m "not performance"
+              pytest tests/TimeLocker/ -v --tb=short --maxfail=10 -m "not performance" -n auto
 
       - name: Run unit tests with coverage
         env:
           PYTHONPATH: src
         run:  |
-              pytest tests/TimeLocker/ --cov=src --cov-report=xml --cov-report=html --cov-report=term-missing --cov-fail-under=70 -m "not performance"
+              pytest tests/TimeLocker/ --cov=src --cov-report=xml --cov-report=html --cov-report=term-missing --cov-fail-under=70 -m "not performance" -n auto
 
       - name: Run integration tests
         env:
           PYTHONPATH: src
         run:  |
-              pytest tests/TimeLocker/integration/ -v --tb=short
+              pytest tests/TimeLocker/integration/ -v --tb=short -n auto
 
       - name: Run security tests
         env:
           PYTHONPATH: src
         run:  |
-              pytest tests/TimeLocker/security/ -v --tb=short
+              pytest tests/TimeLocker/security/ -v --tb=short -n auto
 
       - name: Run critical path tests
         env:
           PYTHONPATH: src
         run:  |
-              pytest tests/TimeLocker/backup/test_critical_backup_paths.py -v --tb=short
+              pytest tests/TimeLocker/backup/test_critical_backup_paths.py -v --tb=short -n auto
 
       - name: Run performance tests (serial)
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ htmlcov/
 
 # Project artifacts
 performance_metrics.json
+/tests.log

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 # Pytest configuration for TimeLocker MVP
 
 # Test discovery
@@ -47,8 +47,6 @@ filterwarnings =
 # Minimum version requirements
 minversion = 6.0
 
-# Test timeout (in seconds)
-timeout = 300
 
 # Log configuration
 log_cli = true
@@ -62,15 +60,6 @@ log_file_level = DEBUG
 log_file_format = %(asctime)s [%(levelname)8s] %(filename)s:%(lineno)d %(funcName)s(): %(message)s
 log_file_date_format = %Y-%m-%d %H:%M:%S
 
-# Test collection
-collect_ignore =
-  setup.py
-  build
-  dist
-  .git
-  .pytest_cache
-  __pycache__
-  *.egg-info
 
 # Doctest options
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL

--- a/src/TimeLocker/cli.py
+++ b/src/TimeLocker/cli.py
@@ -2070,8 +2070,8 @@ def backup_verify(
     try:
         if repository:
             validate_repository_name_or_uri(repository)
-        if snapshot and snapshot.lower() != "latest":
-            validate_snapshot_id_format(snapshot)
+        if snapshot:
+            validate_snapshot_id_format(snapshot, allow_latest=True)
     except ValueError as ve:
         show_error_panel("Invalid Input", str(ve))
         raise typer.Exit(1)

--- a/src/TimeLocker/cli.py
+++ b/src/TimeLocker/cli.py
@@ -44,6 +44,9 @@ from .completion import (
 )
 from .importers.timeshift_importer import TimeshiftConfigParser, TimeshiftToTimeLockerMapper
 
+from .utils.repository_resolver import validate_repository_name_or_uri
+from .utils.snapshot_validation import validate_snapshot_id_format
+
 # Test-friendly patch: ensure stderr is captured separately in Typer's CliRunner
 # so tests can safely access result.stderr when using CliRunner.
 try:
@@ -521,6 +524,15 @@ def snapshots_restore(
     """Restore files from this snapshot."""
     setup_logging(verbose)
 
+    # Validate inputs early
+    try:
+        if repository:
+            validate_repository_name_or_uri(repository)
+        validate_snapshot_id_format(snapshot_id, allow_latest=True)
+    except ValueError as ve:
+        show_error_panel("Invalid Input", str(ve))
+        raise typer.Exit(1)
+
     try:
         # Resolve repository name to URI
         from .utils.repository_resolver import resolve_repository_uri
@@ -656,6 +668,14 @@ def snapshots_list(
 ) -> None:
     """List snapshots in repository with a beautiful table."""
     setup_logging(verbose)
+    # Validate repository option (syntactic) before resolution
+    try:
+        if repository:
+            validate_repository_name_or_uri(repository)
+    except ValueError as ve:
+        show_error_panel("Invalid Repository", str(ve))
+        raise typer.Exit(1)
+
 
     try:
         # Resolve repository name to URI
@@ -2046,6 +2066,16 @@ def backup_verify(
     """Verify backup integrity. Verifies the latest snapshot by default unless --snapshot is specified."""
     setup_logging(verbose)
 
+    # Validate options early
+    try:
+        if repository:
+            validate_repository_name_or_uri(repository)
+        if snapshot and snapshot.lower() != "latest":
+            validate_snapshot_id_format(snapshot)
+    except ValueError as ve:
+        show_error_panel("Invalid Input", str(ve))
+        raise typer.Exit(1)
+
     try:
         # Resolve repository name to URI
         from .utils.repository_resolver import resolve_repository_uri
@@ -2127,6 +2157,15 @@ def snapshots_show(
 ) -> None:
     """Show snapshot details."""
     setup_logging(verbose)
+    # Validate inputs early
+    try:
+        if repository:
+            validate_repository_name_or_uri(repository)
+        validate_snapshot_id_format(snapshot_id)
+    except ValueError as ve:
+        show_error_panel("Invalid Input", str(ve))
+        raise typer.Exit(1)
+
 
     try:
         service_manager = get_cli_service_manager()
@@ -2190,6 +2229,15 @@ def snapshots_contents(
 ) -> None:
     """List contents of a specific snapshot."""
     setup_logging(verbose)
+    # Validate inputs early
+    try:
+        if repository:
+            validate_repository_name_or_uri(repository)
+        validate_snapshot_id_format(snapshot_id)
+    except ValueError as ve:
+        show_error_panel("Invalid Input", str(ve))
+        raise typer.Exit(1)
+
 
     try:
         service_manager = get_cli_service_manager()
@@ -2248,6 +2296,15 @@ def snapshots_mount(
 ) -> None:
     """Mount this snapshot as filesystem."""
     setup_logging(verbose)
+    # Validate inputs early
+    try:
+        if repository:
+            validate_repository_name_or_uri(repository)
+        validate_snapshot_id_format(snapshot_id)
+    except ValueError as ve:
+        show_error_panel("Invalid Input", str(ve))
+        raise typer.Exit(1)
+
 
     try:
         service_manager = get_cli_service_manager()
@@ -2286,6 +2343,15 @@ def snapshots_umount(
 ) -> None:
     """Unmount this snapshot."""
     setup_logging(verbose)
+    # Validate snapshot ID early
+    try:
+        validate_snapshot_id_format(snapshot_id)
+        if repository:
+            validate_repository_name_or_uri(repository)
+    except ValueError as ve:
+        show_error_panel("Invalid Input", str(ve))
+        raise typer.Exit(1)
+
 
     try:
         service_manager = get_cli_service_manager()
@@ -2318,6 +2384,15 @@ def snapshots_find_in(
 ) -> None:
     """Search within a specific snapshot."""
     setup_logging(verbose)
+    # Validate inputs early
+    try:
+        if repository:
+            validate_repository_name_or_uri(repository)
+        validate_snapshot_id_format(snapshot_id)
+    except ValueError as ve:
+        show_error_panel("Invalid Input", str(ve))
+        raise typer.Exit(1)
+
 
     try:
         service_manager = get_cli_service_manager()
@@ -2375,6 +2450,15 @@ def snapshots_forget(
 ) -> None:
     """Remove this specific snapshot."""
     setup_logging(verbose)
+    # Validate inputs early
+    try:
+        if repository:
+            validate_repository_name_or_uri(repository)
+        validate_snapshot_id_format(snapshot_id)
+    except ValueError as ve:
+        show_error_panel("Invalid Input", str(ve))
+        raise typer.Exit(1)
+
 
     try:
         service_manager = get_cli_service_manager()

--- a/src/TimeLocker/config/configuration_module.py
+++ b/src/TimeLocker/config/configuration_module.py
@@ -345,6 +345,14 @@ class ConfigurationModule(IConfigurationProvider):
                 self._load_configuration()
             return self._config_cache
 
+
+    def get_configuration(self) -> Dict[str, Any]:
+        """Get complete configuration as a plain dictionary (legacy-compatible).
+        Returns a JSON-serializable dict representing current configuration.
+        """
+        cfg = self.get_config()
+        return cfg.to_dict()
+
     def save_config(self, config: Optional[TimeLockerConfig] = None) -> None:
         """Save complete configuration.
 

--- a/src/TimeLocker/config/configuration_schema.py
+++ b/src/TimeLocker/config/configuration_schema.py
@@ -310,7 +310,7 @@ class TimeLockerConfig:
             if 'uri' in repo_data_copy:
                 repo_data_copy['location'] = repo_data_copy.pop('uri')
             # Remove legacy fields not supported by new RepositoryConfig
-            legacy_fields = ['type', 'created']
+            legacy_fields = ['type', 'created', 'encryption']
             for field in legacy_fields:
                 repo_data_copy.pop(field, None)
             repositories[name] = RepositoryConfig(name=name, **repo_data_copy)

--- a/src/TimeLocker/utils/snapshot_validation.py
+++ b/src/TimeLocker/utils/snapshot_validation.py
@@ -1,0 +1,44 @@
+"""
+Snapshot ID validation utilities for TimeLocker CLI.
+
+Rules (aligned with restic snapshot IDs):
+- Hexadecimal ID (case-insensitive), length between 8 and 64 characters (inclusive)
+- No whitespace; no punctuation other than hex
+- Optionally allow special keyword "latest" when CLI semantics permit
+"""
+
+import re
+from typing import Optional
+
+_HEX_RE = re.compile(r"^[0-9a-fA-F]{8,64}$")
+
+
+def validate_snapshot_id_format(value: Optional[str], allow_latest: bool = False) -> None:
+    """
+    Validate snapshot identifier format.
+
+    Args:
+        value: The snapshot identifier string.
+        allow_latest: If True, the special value "latest" is accepted.
+
+    Raises:
+        ValueError: If the value is not a valid snapshot identifier.
+    """
+    if value is None:
+        raise ValueError("Snapshot ID is required")
+
+    v = value.strip()
+    if not v:
+        raise ValueError("Snapshot ID cannot be empty")
+
+    if allow_latest and v.lower() == "latest":
+        return
+
+    if not _HEX_RE.match(v):
+        raise ValueError(
+            "Invalid snapshot ID format. Expected 8–64 hexadecimal characters (e.g., 1a2b3c4d...)."
+        )
+
+    # OK
+    return
+

--- a/tests/TimeLocker/cli/test_snapshot_id_cli_validation.py
+++ b/tests/TimeLocker/cli/test_snapshot_id_cli_validation.py
@@ -1,0 +1,22 @@
+import re
+from typer.testing import CliRunner
+
+from src.TimeLocker.cli import app
+
+runner = CliRunner()
+
+def _combined_output(result):
+    # Combine stdout and stderr for matching convenience across environments
+    out = result.stdout or ""
+    err = getattr(result, "stderr", "") or ""
+    return out + "\n" + err
+
+
+def test_umount_rejects_invalid_snapshot_id():
+    result = runner.invoke(app, ["snapshots", "umount", "bad$$id"])  # repository not needed for umount
+    combined = _combined_output(result)
+
+    assert result.exit_code != 0
+    # Check for our validation message
+    assert re.search(r"Invalid\s+snapshot\s+ID\s+format", combined, flags=re.IGNORECASE)
+

--- a/tests/test_snapshot_id_validation.py
+++ b/tests/test_snapshot_id_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from TimeLocker.utils.snapshot_validation import validate_snapshot_id_format
+from src.TimeLocker.utils.snapshot_validation import validate_snapshot_id_format
 
 
 @pytest.mark.parametrize("value", [

--- a/tests/test_snapshot_id_validation.py
+++ b/tests/test_snapshot_id_validation.py
@@ -1,0 +1,37 @@
+import pytest
+
+from TimeLocker.utils.snapshot_validation import validate_snapshot_id_format
+
+
+@pytest.mark.parametrize("value", [
+    "12345678",
+    "abcdef12",
+    "ABCDEF12",
+    "a" * 64,
+])
+def test_validate_accepts_valid_snapshot_ids(value):
+    # Should not raise
+    validate_snapshot_id_format(value)
+
+
+@pytest.mark.parametrize("value", [
+    "",  # empty
+    "1234567",  # too short
+    "g1234567",  # non-hex
+    "bad$$id",  # invalid chars
+])
+def test_validate_rejects_invalid_snapshot_ids(value):
+    with pytest.raises(ValueError) as exc:
+        validate_snapshot_id_format(value)
+    msg = str(exc.value).lower()
+    assert ("hexadecimal" in msg) or ("empty" in msg)
+
+
+def test_allow_latest_flag():
+    # Without flag, 'latest' is invalid
+    with pytest.raises(ValueError):
+        validate_snapshot_id_format("latest")
+
+    # With flag, allowed
+    validate_snapshot_id_format("latest", allow_latest=True)
+


### PR DESCRIPTION
Add input validation for snapshot IDs and repository names across CLI commands

Implements centralized validation to provide immediate, user-friendly error messages when invalid snapshot IDs or repository names are provided to CLI commands. This prevents cryptic backend failures and improves the overall user experience.

**Key Changes:**
- **Snapshot ID validation**: Validates 8-64 hexadecimal characters (case-insensitive) with optional "latest" keyword support
- **Early validation**: Integrates validation into 8 CLI commands (restore, list, verify, show, contents, mount, umount, find-in, forget) with consistent error handling and exit codes
- **Repository validation**: Leverages existing repository name/URI validation for consistent input checking
- **Test coverage**: Adds comprehensive unit tests for validation logic and CLI integration tests
- **pytest configuration fix**: Corrects `pytest.ini` header and removes unsupported options to eliminate warnings and stabilize test runs

**Impact:**
- Users receive clear, actionable error messages for invalid inputs instead of backend failures
- Consistent validation behavior across all snapshot-related CLI commands
- Improved developer experience with stable pytest configuration
- Enhanced reliability by preventing invalid data from reaching backend systems

Fixes #6

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*