### PR TITLE
fix(tests): prevent CLI help text truncation in CI environments

### DIFF
--- a/tests/TimeLocker/cli/test_snapshot_id_cli_validation.py
+++ b/tests/TimeLocker/cli/test_snapshot_id_cli_validation.py
@@ -4,7 +4,8 @@ from typer.testing import CliRunner
 
 from src.TimeLocker.cli import app
 
-runner = CliRunner()
+# Set wider terminal width to prevent help text truncation in CI
+runner = CliRunner(env={'COLUMNS': '200'})
 
 def _combined_output(result):
     # Combine stdout and stderr for matching convenience across environments

--- a/tests/TimeLocker/cli/test_user_experience_validation.py
+++ b/tests/TimeLocker/cli/test_user_experience_validation.py
@@ -28,7 +28,8 @@ class TestUserExperienceValidation:
         self.config_dir = self.temp_dir / "config"
         self.config_dir.mkdir(parents=True)
 
-        self.runner = CliRunner()
+        # Set wider terminal width to prevent help text truncation in CI
+        self.runner = CliRunner(env={'COLUMNS': '200'})
 
     def teardown_method(self):
         """Cleanup test environment"""

--- a/tests/TimeLocker/integration/test_timeshift_cli_integration.py
+++ b/tests/TimeLocker/integration/test_timeshift_cli_integration.py
@@ -17,7 +17,8 @@ class TestTimeshiftCLIIntegration:
 
     def setup_method(self):
         """Set up test environment"""
-        self.runner = CliRunner()
+        # Set wider terminal width to prevent help text truncation in CI
+        self.runner = CliRunner(env={'COLUMNS': '200'})
 
         # Create sample Timeshift configuration
         self.timeshift_config = {


### PR DESCRIPTION
Fix CLI help text truncation in CI environments by setting wider terminal width for test runners.

This resolves the failing `test_timeshift_import_help` test which was unable to find `--config-file` in the help output due to text truncation caused by narrow terminal widths in GitHub Actions and other CI environments.

## Changes

- Set `COLUMNS=200` environment variable for `CliRunner` instances in CLI test files
- Ensures complete help text display across all execution environments
- Prevents test failures caused by terminal width constraints

## Impact

- **Test Reliability**: Eliminates environment-dependent test failures
- **CI Stability**: Ensures consistent test behavior in GitHub Actions
- **Developer Experience**: Reduces false negatives in automated testing

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*