### PR TITLE
feat(credentials): implement per-repository backend credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,12 @@ htmlcov/
 performance_metrics.json
 /tests.log
 /coverage.xml
+temp/
+
+# Test configuration (contains credentials)
+test-config.json
+test-config.*.json
+.env.test
+
+# MinIO data
+minio-data/

--- a/src/TimeLocker/cli.py
+++ b/src/TimeLocker/cli.py
@@ -1794,7 +1794,7 @@ def repos_add(
 
     # Enforce file:// for local paths
     try:
-        from .utils.repository_resolver import validate_repository_name_or_uri
+        from .utils.repository_resolver import validate_repository_name_or_uri, normalize_repository_uri
         validate_repository_name_or_uri(uri)
     except ValueError as ve:
         show_error_panel(
@@ -1803,6 +1803,8 @@ def repos_add(
         )
         raise typer.Exit(1)
 
+    # Normalize URI to restic format (e.g., s3://host/bucket -> s3:host/bucket)
+    normalized_uri = normalize_repository_uri(uri)
 
     try:
         from .config.configuration_module import ConfigurationModule
@@ -1813,10 +1815,10 @@ def repos_add(
         logger = logging.getLogger(__name__)
         config_manager = ConfigurationModule(config_dir=config_dir)
 
-        # Add repository configuration
+        # Add repository configuration with normalized URI
         repository_config = {
                 'name':        name,
-                'location':    uri,
+                'location':    normalized_uri,
                 'description': description or f"{name} repository"
         }
         config_manager.add_repository(repository_config)
@@ -1855,13 +1857,98 @@ def repos_add(
                 config_manager.update_repository(name, repository_config)
                 logger.debug(f"Password stored temporarily in configuration for repository '{name}': {e}")
 
+        # Handle backend credentials for S3/B2 repositories
+        backend_credentials_stored = False
+        if normalized_uri.startswith(('s3://', 's3:')):
+            # S3 repository - prompt for AWS credentials
+            if Confirm.ask(f"Would you like to store AWS credentials for repository '{name}'?", default=True):
+                console.print("\n[bold]AWS Credentials:[/bold]")
+                access_key_id = Prompt.ask("AWS Access Key ID", password=True)
+                secret_access_key = Prompt.ask("AWS Secret Access Key", password=True)
+                region = Prompt.ask("AWS Region (optional, press Enter to skip)", default="")
+
+                # Store credentials in credential manager
+                credential_manager = CredentialManager()
+                if credential_manager.is_locked():
+                    if not credential_manager.ensure_unlocked(allow_prompt=True):
+                        console.print("[yellow]⚠️  Could not unlock credential manager. Backend credentials not stored.[/yellow]")
+                    else:
+                        credentials_dict = {
+                            "access_key_id": access_key_id,
+                            "secret_access_key": secret_access_key,
+                        }
+                        if region:
+                            credentials_dict["region"] = region
+
+                        credential_manager.store_repository_backend_credentials(name, "s3", credentials_dict)
+
+                        # Update repository config to indicate credentials are stored
+                        repository_config['has_backend_credentials'] = True
+                        config_manager.update_repository(name, repository_config)
+                        backend_credentials_stored = True
+                        logger.info(f"AWS credentials stored for repository '{name}'")
+                else:
+                    credentials_dict = {
+                        "access_key_id": access_key_id,
+                        "secret_access_key": secret_access_key,
+                    }
+                    if region:
+                        credentials_dict["region"] = region
+
+                    credential_manager.store_repository_backend_credentials(name, "s3", credentials_dict)
+
+                    # Update repository config to indicate credentials are stored
+                    repository_config['has_backend_credentials'] = True
+                    config_manager.update_repository(name, repository_config)
+                    backend_credentials_stored = True
+                    logger.info(f"AWS credentials stored for repository '{name}'")
+
+        elif normalized_uri.startswith(('b2://', 'b2:')):
+            # B2 repository - prompt for B2 credentials
+            if Confirm.ask(f"Would you like to store B2 credentials for repository '{name}'?", default=True):
+                console.print("\n[bold]B2 Credentials:[/bold]")
+                account_id = Prompt.ask("B2 Account ID", password=True)
+                account_key = Prompt.ask("B2 Account Key", password=True)
+
+                # Store credentials in credential manager
+                credential_manager = CredentialManager()
+                if credential_manager.is_locked():
+                    if not credential_manager.ensure_unlocked(allow_prompt=True):
+                        console.print("[yellow]⚠️  Could not unlock credential manager. Backend credentials not stored.[/yellow]")
+                    else:
+                        credentials_dict = {
+                            "account_id": account_id,
+                            "account_key": account_key,
+                        }
+
+                        credential_manager.store_repository_backend_credentials(name, "b2", credentials_dict)
+
+                        # Update repository config to indicate credentials are stored
+                        repository_config['has_backend_credentials'] = True
+                        config_manager.update_repository(name, repository_config)
+                        backend_credentials_stored = True
+                        logger.info(f"B2 credentials stored for repository '{name}'")
+                else:
+                    credentials_dict = {
+                        "account_id": account_id,
+                        "account_key": account_key,
+                    }
+
+                    credential_manager.store_repository_backend_credentials(name, "b2", credentials_dict)
+
+                    # Update repository config to indicate credentials are stored
+                    repository_config['has_backend_credentials'] = True
+                    config_manager.update_repository(name, repository_config)
+                    backend_credentials_stored = True
+                    logger.info(f"B2 credentials stored for repository '{name}'")
+
         # Set as default if requested
         if set_default:
             config_manager.set_default_repository(name)
 
         # Build success message
         success_details = [
-                f"📍 URI: {uri}",
+                f"📍 URI: {normalized_uri}",
                 f"📝 Description: {description or f'{name} repository'}",
                 f"🎯 Default: {'Yes' if set_default else 'No'}",
         ]
@@ -1872,6 +1959,10 @@ def repos_add(
             success_details.append("🔐 Password: Provided (will be stored during initialization)")
         else:
             success_details.append("🔐 Password: Not provided")
+
+        if backend_credentials_stored:
+            backend_type = "AWS" if normalized_uri.startswith(('s3://', 's3:')) else "B2"
+            success_details.append(f"🔑 {backend_type} Credentials: Stored securely")
 
         console.print()
         console.print(Panel(
@@ -1983,6 +2074,235 @@ def repos_default(
         raise typer.Exit(1)
     except Exception as e:
         show_error_panel("Configuration Error", f"Failed to set default repository: {e}")
+        if verbose:
+            console.print_exception()
+        raise typer.Exit(1)
+
+
+@repos_app.command("credentials-set")
+def repos_credentials_set(
+        name: Annotated[str, typer.Argument(help="Repository name", autocompletion=repository_name_completer)],
+        config_dir: Annotated[Optional[Path], typer.Option("--config-dir", help="Configuration directory")] = None,
+        verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output")] = False,
+) -> None:
+    """Set or update backend credentials for a repository."""
+    setup_logging(verbose)
+
+    try:
+        from .config.configuration_module import ConfigurationModule
+        from .security.credential_manager import CredentialManager
+        from .interfaces.exceptions import RepositoryNotFoundError
+        import logging
+        logger = logging.getLogger(__name__)
+
+        config_manager = ConfigurationModule(config_dir=config_dir)
+
+        # Get repository configuration
+        try:
+            repo_config = config_manager.get_repository(name)
+        except:
+            show_error_panel("Repository Not Found", f"Repository '{name}' not found")
+            raise typer.Exit(1)
+
+        # Determine repository type from URI
+        uri = repo_config.get('uri', '')
+        if uri.startswith(('s3://', 's3:')):
+            backend_type = "s3"
+            console.print(f"\n[bold]Setting AWS credentials for repository '{name}'[/bold]")
+            access_key_id = Prompt.ask("AWS Access Key ID", password=True)
+            secret_access_key = Prompt.ask("AWS Secret Access Key", password=True)
+            region = Prompt.ask("AWS Region (optional, press Enter to skip)", default="")
+
+            credentials_dict = {
+                "access_key_id": access_key_id,
+                "secret_access_key": secret_access_key,
+            }
+            if region:
+                credentials_dict["region"] = region
+
+        elif uri.startswith(('b2://', 'b2:')):
+            backend_type = "b2"
+            console.print(f"\n[bold]Setting B2 credentials for repository '{name}'[/bold]")
+            account_id = Prompt.ask("B2 Account ID", password=True)
+            account_key = Prompt.ask("B2 Account Key", password=True)
+
+            credentials_dict = {
+                "account_id": account_id,
+                "account_key": account_key,
+            }
+
+        else:
+            show_error_panel(
+                "Unsupported Repository Type",
+                f"Backend credentials are only supported for S3 and B2 repositories.\n"
+                f"Repository '{name}' has URI: {uri}"
+            )
+            raise typer.Exit(1)
+
+        # Store credentials
+        credential_manager = CredentialManager()
+        if credential_manager.is_locked():
+            if not credential_manager.ensure_unlocked(allow_prompt=True):
+                show_error_panel("Credential Manager Locked", "Could not unlock credential manager")
+                raise typer.Exit(1)
+
+        credential_manager.store_repository_backend_credentials(name, backend_type, credentials_dict)
+
+        # Update repository config to indicate credentials are stored
+        repo_config_update = {'has_backend_credentials': True}
+        config_manager.update_repository(name, repo_config_update)
+
+        console.print()
+        console.print(Panel(
+            f"✅ {backend_type.upper()} credentials stored successfully for repository '{name}'!",
+            title="[bold green]Credentials Stored[/bold green]",
+            border_style="green"
+        ))
+
+    except Exception as e:
+        show_error_panel("Error", f"Failed to set credentials: {e}")
+        if verbose:
+            console.print_exception()
+        raise typer.Exit(1)
+
+
+@repos_app.command("credentials-remove")
+def repos_credentials_remove(
+        name: Annotated[str, typer.Argument(help="Repository name", autocompletion=repository_name_completer)],
+        config_dir: Annotated[Optional[Path], typer.Option("--config-dir", help="Configuration directory")] = None,
+        verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output")] = False,
+        yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation prompt")] = False,
+) -> None:
+    """Remove backend credentials for a repository."""
+    setup_logging(verbose)
+
+    try:
+        from .config.configuration_module import ConfigurationModule
+        from .security.credential_manager import CredentialManager
+        from .interfaces.exceptions import RepositoryNotFoundError
+
+        config_manager = ConfigurationModule(config_dir=config_dir)
+
+        # Get repository configuration
+        try:
+            repo_config = config_manager.get_repository(name)
+        except:
+            show_error_panel("Repository Not Found", f"Repository '{name}' not found")
+            raise typer.Exit(1)
+
+        # Determine repository type from URI
+        uri = repo_config.get('uri', '')
+        if uri.startswith(('s3://', 's3:')):
+            backend_type = "s3"
+        elif uri.startswith(('b2://', 'b2:')):
+            backend_type = "b2"
+        else:
+            show_error_panel(
+                "Unsupported Repository Type",
+                f"Backend credentials are only supported for S3 and B2 repositories.\n"
+                f"Repository '{name}' has URI: {uri}"
+            )
+            raise typer.Exit(1)
+
+        # Confirm removal unless --yes flag is used
+        if not yes:
+            if not Confirm.ask(f"Remove {backend_type.upper()} credentials for repository '{name}'?"):
+                console.print("[yellow]Cancelled[/yellow]")
+                raise typer.Exit(0)
+
+        # Remove credentials
+        credential_manager = CredentialManager()
+        if credential_manager.is_locked():
+            if not credential_manager.ensure_unlocked(allow_prompt=True):
+                show_error_panel("Credential Manager Locked", "Could not unlock credential manager")
+                raise typer.Exit(1)
+
+        removed = credential_manager.remove_repository_backend_credentials(name, backend_type)
+
+        if removed:
+            # Update repository config
+            repo_config_update = {'has_backend_credentials': False}
+            config_manager.update_repository(name, repo_config_update)
+
+            console.print()
+            console.print(Panel(
+                f"✅ {backend_type.upper()} credentials removed for repository '{name}'",
+                title="[bold green]Credentials Removed[/bold green]",
+                border_style="green"
+            ))
+        else:
+            console.print(f"[yellow]No credentials found for repository '{name}'[/yellow]")
+
+    except Exception as e:
+        show_error_panel("Error", f"Failed to remove credentials: {e}")
+        if verbose:
+            console.print_exception()
+        raise typer.Exit(1)
+
+
+@repos_app.command("credentials-show")
+def repos_credentials_show(
+        name: Annotated[str, typer.Argument(help="Repository name", autocompletion=repository_name_completer)],
+        config_dir: Annotated[Optional[Path], typer.Option("--config-dir", help="Configuration directory")] = None,
+        verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable verbose output")] = False,
+) -> None:
+    """Show whether backend credentials are configured for a repository."""
+    setup_logging(verbose)
+
+    try:
+        from .config.configuration_module import ConfigurationModule
+        from .security.credential_manager import CredentialManager
+        from .interfaces.exceptions import RepositoryNotFoundError
+
+        config_manager = ConfigurationModule(config_dir=config_dir)
+
+        # Get repository configuration
+        try:
+            repo_config = config_manager.get_repository(name)
+        except:
+            show_error_panel("Repository Not Found", f"Repository '{name}' not found")
+            raise typer.Exit(1)
+
+        # Determine repository type from URI
+        uri = repo_config.get('uri', '')
+        if uri.startswith(('s3://', 's3:')):
+            backend_type = "s3"
+            backend_name = "AWS"
+        elif uri.startswith(('b2://', 'b2:')):
+            backend_type = "b2"
+            backend_name = "B2"
+        else:
+            console.print(f"[dim]Repository '{name}' does not use S3 or B2 backend[/dim]")
+            console.print(f"[dim]URI: {uri}[/dim]")
+            raise typer.Exit(0)
+
+        # Check if credentials are stored
+        credential_manager = CredentialManager()
+        if credential_manager.is_locked():
+            if not credential_manager.ensure_unlocked(allow_prompt=True):
+                show_error_panel("Credential Manager Locked", "Could not unlock credential manager")
+                raise typer.Exit(1)
+
+        has_credentials = credential_manager.has_repository_backend_credentials(name, backend_type)
+
+        console.print()
+        if has_credentials:
+            console.print(Panel(
+                f"✅ {backend_name} credentials are configured for repository '{name}'\n\n"
+                f"[dim]Note: Actual credential values are encrypted and not displayed[/dim]",
+                title=f"[bold green]{backend_name} Credentials Status[/bold green]",
+                border_style="green"
+            ))
+        else:
+            console.print(Panel(
+                f"❌ No {backend_name} credentials configured for repository '{name}'\n\n"
+                f"💡 Use [cyan]tl repos credentials-set {name}[/cyan] to add credentials",
+                title=f"[bold yellow]{backend_name} Credentials Status[/bold yellow]",
+                border_style="yellow"
+            ))
+
+    except Exception as e:
+        show_error_panel("Error", f"Failed to check credentials: {e}")
         if verbose:
             console.print_exception()
         raise typer.Exit(1)

--- a/src/TimeLocker/cli.py
+++ b/src/TimeLocker/cli.py
@@ -2105,7 +2105,7 @@ def repos_credentials_set(
             raise typer.Exit(1)
 
         # Determine repository type from URI
-        uri = repo_config.get('uri', '')
+        uri = repo_config.get('uri') or repo_config.get('location', '')
         if uri.startswith(('s3://', 's3:')):
             backend_type = "s3"
             console.print(f"\n[bold]Setting AWS credentials for repository '{name}'[/bold]")

--- a/src/TimeLocker/config/configuration_schema.py
+++ b/src/TimeLocker/config/configuration_schema.py
@@ -155,6 +155,7 @@ class RepositoryConfig:
     tags: List[str] = field(default_factory=list)
     enabled: bool = True
     read_only: bool = False
+    has_backend_credentials: bool = False  # Flag indicating backend credentials are stored in credential manager
 
     def __post_init__(self):
         # If only 'path' was provided, treat it as 'location'

--- a/src/TimeLocker/services/repository_factory.py
+++ b/src/TimeLocker/services/repository_factory.py
@@ -114,15 +114,16 @@ class RepositoryFactory(IRepositoryFactory):
                           **kwargs) -> BackupRepository:
         """
         Create a repository instance from URI.
-        
+
         Args:
             uri: Repository URI
             password: Optional password for repository
             **kwargs: Additional repository-specific parameters
-            
+                     repository_name: Optional repository name for credential lookup
+
         Returns:
             BackupRepository instance
-            
+
         Raises:
             UnsupportedSchemeError: If URI scheme is not supported
             RepositoryFactoryError: If repository creation fails
@@ -158,6 +159,10 @@ class RepositoryFactory(IRepositoryFactory):
             # Provide credential manager to repository
             kwargs['credential_manager'] = self._get_credential_manager()
             logger.debug("Credential manager added to kwargs")
+
+            # Pass repository_name if provided (for per-repository credential lookup)
+            if 'repository_name' in kwargs:
+                logger.debug(f"Repository name provided for credential lookup: {kwargs['repository_name']}")
 
             # Use from_parsed_uri class method if available, otherwise fall back to constructor
             if hasattr(repository_class, 'from_parsed_uri'):

--- a/src/TimeLocker/services/validation_service.py
+++ b/src/TimeLocker/services/validation_service.py
@@ -161,7 +161,9 @@ class ValidationService:
 
             # Validate remote URIs
             elif scheme in {'s3', 'b2', 'azure', 'gcs'}:
-                if not parsed.netloc:
+                # Support both standard format (s3://host/bucket) and restic format (s3:host/bucket)
+                # Standard format has netloc, restic format has everything in path
+                if not parsed.netloc and not parsed.path:
                     result.add_error(f"{scheme.upper()} URI must have a hostname/bucket")
 
         except Exception as e:


### PR DESCRIPTION
Add per-repository backend credential management for S3 and B2 repositories

This implementation enables each repository to store and use its own isolated backend credentials, allowing multiple repositories with different credentials on the same backend type (S3 or B2).

**Key Changes:**
• **Secure credential storage** - Add `store_repository_backend_credentials()` and `get_repository_backend_credentials()` methods to CredentialManager for isolated per-repository credential storage
• **Backend integration** - Update S3ResticRepository and B2ResticRepository to retrieve and use per-repository credentials with fallback to environment variables
• **Interactive credential setup** - Add CLI prompts in `repos add` command to capture and store S3/B2 credentials when adding repositories
• **Credential management commands** - Add `repos credentials-set`, `repos credentials-remove`, and `repos credentials-show` commands for managing repository credentials
• **URI normalization** - Implement `normalize_repository_uri()` to convert standard URIs (s3://host/bucket) to restic format (s3:host/bucket) for consistent configuration storage
• **Factory integration** - Update RepositoryFactory to pass repository names to backend classes for credential lookup

**Benefits:**
- Enables multi-tenant scenarios where different repositories use different cloud storage accounts
- Maintains backward compatibility with existing environment variable-based credential configuration  
- Provides secure, encrypted storage of credentials through the existing credential manager
- Simplifies credential management for users with multiple cloud storage backends

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*