### PR TITLE
fix(release): provide repository context to publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release create "$GITHUB_REF_NAME" dist/* \
             --verify-tag \

--- a/scripts/validate_release_workflows.py
+++ b/scripts/validate_release_workflows.py
@@ -42,6 +42,9 @@ def validate(rehearsal_path: Path, release_path: Path) -> None:
     ), "only the publication job may request contents: write"
     assert release.count("contents: write") == 1
     assert release.count("gh release create") == 1
+    assert "GH_REPO: ${{ github.repository }}" in release, (
+        "checkout-free publication must provide explicit GitHub repository context"
+    )
 
 
 def main() -> None:


### PR DESCRIPTION
Summary: fixes the v0.9.1 publication failure by providing GH_REPO to the checkout-free publish job and enforcing that contract in release workflow validation. Evidence: release workflow validator passed; release artifact project tests passed (11 tests); diff check passed. The v0.9.1 validation job passed, and only release creation failed because GitHub CLI could not infer a repository without a checkout. Refs #24